### PR TITLE
Remove sleep while setting a port in config DB

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -199,8 +199,6 @@ class ConfigDBConnector(SonicV2Connector):
             client.delete(_hash)
         else:
             client.hmset(_hash, self.__typed_to_raw(data))
-            if table == "PORT":
-                time.sleep(2)
 
     def get_entry(self, table, key):
         """Read a table entry from config db.


### PR DESCRIPTION
This was introduced to order the ports while creating. That is to create root port before child ports.
Since BRCM fixed the underlying issue and now we can create ports in any order, removing this.

This has been tested and verified extensively.