### PR TITLE
[configdb.py]: Allow field deletion under a primary key.

### DIFF
--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -131,21 +131,22 @@ class ConfigDBConnector(SonicV2Connector):
                     typed_data[key] = raw_data[raw_key]
         return typed_data
 
-    def __typed_to_raw(self, typed_data, dkeys=None):
+    def __typed_to_raw(self, typed_data):
+        raw_data = dict(); dfields = dict()
         if typed_data == None:
-            return None
+            return raw_data, dfields
         elif typed_data == {}:
-            return { "NULL": "NULL" }
-        raw_data = {}
+            return { "NULL": "NULL" }, dfields
+
         for key in typed_data:
             value = typed_data[key]
             if type(value) is list:
                 raw_data[key+'@'] = ','.join(value)
-            elif value is None and dkeys is not None:
-                dkeys[key] = None
+            elif value is None:
+                dfields[key] = None
             else:
                 raw_data[key] = str(value)
-        return raw_data
+        return raw_data, dfields
 
     @staticmethod
     def serialize_key(key):
@@ -179,11 +180,16 @@ class ConfigDBConnector(SonicV2Connector):
             client.delete(_hash)
         else:
             original = self.get_entry(table, key)
-            client.hmset(_hash, self.__typed_to_raw(data))
-            for k in [ k for k in original.keys() if k not in data.keys() ]:
+            raw, _ = self.__typed_to_raw(data)
+            if len(raw):
+                client.hmset(_hash, raw)
+
+            for k in original.keys():
                 if type(original[k]) == list:
                     k = k + '@'
-                client.hdel(_hash, self.serialize_key(k))
+                if k not in raw.keys():
+                    client.hdel(_hash, self.serialize_key(k))
+        return
 
     def mod_entry(self, table, key, data):
         """Modify a table entry to config db.
@@ -200,36 +206,21 @@ class ConfigDBConnector(SonicV2Connector):
         if data == None:
             client.delete(_hash)
         else:
-            # We allow deletion of field by setting them to None, __typed_to_raw()
-            # will fill keys to be deleted in dkeys arg.
-            dkeys = dict()
-            raw = self.__typed_to_raw(data, dkeys)
-            if raw and len(raw):
-                client.hmset(_hash, raw)
-            # check if any dkeys(i.e. fields) to be deleted
-            if len(dkeys):
-                # get the original first, nothing to do if original is None
+            raw, dfields = self.__typed_to_raw(data)
+            # We allow deletion of field by setting them to None
+            if len(dfields):
+                # get the original first,
                 original = self.get_entry(table, key)
-                if original:
-                    self.__delete_fields(client, _hash, dkeys, original)
-
-            return
-
-    def __delete_fields(self, client, _hash, fields, original):
-        """Delete fields under a key(_hash) of a table in config db.
-        Args:
-            client: db client
-            _hash: _hash of the key, where fields to be deleted
-            fields: fields to be deleted, a dict as {field1: None, field2: None, ...}
-            original: original value of _hash i.e. field, value dict.
-        """
-        for k in fields:
-            v = original.get(k)
-            # nothing to do if v is None
-            if v:
-                if type(v) == list:
-                    k = k + '@'
-                client.hdel(_hash, self.serialize_key(k))
+                for k in dfields:
+                    v = original.get(k)
+                    # nothing to do if v is None
+                    if v:
+                        if type(v) == list:
+                            k = k + '@'
+                        client.hdel(_hash, self.serialize_key(k))
+            # set raw
+            if len(raw):
+                client.hmset(_hash, raw)
         return
 
     def get_entry(self, table, key):

--- a/src/swsssdk/configdb.py
+++ b/src/swsssdk/configdb.py
@@ -1,5 +1,5 @@
 """
-SONiC ConfigDB connection module 
+SONiC ConfigDB connection module
 
 Example:
     # Write to config DB
@@ -65,7 +65,7 @@ class ConfigDBConnector(SonicV2Connector):
 
     def subscribe(self, table, handler):
         """Set a handler to handle config change in certain table.
-        Note that a single handler can be registered to different tables by 
+        Note that a single handler can be registered to different tables by
         calling this fuction multiple times.
         Args:
             table: Table name.
@@ -131,7 +131,7 @@ class ConfigDBConnector(SonicV2Connector):
                     typed_data[key] = raw_data[raw_key]
         return typed_data
 
-    def __typed_to_raw(self, typed_data):
+    def __typed_to_raw(self, typed_data, dkeys=None):
         if typed_data == None:
             return None
         elif typed_data == {}:
@@ -141,6 +141,8 @@ class ConfigDBConnector(SonicV2Connector):
             value = typed_data[key]
             if type(value) is list:
                 raw_data[key+'@'] = ','.join(value)
+            elif value is None and dkeys is not None:
+                dkeys[key] = None
             else:
                 raw_data[key] = str(value)
         return raw_data
@@ -198,14 +200,44 @@ class ConfigDBConnector(SonicV2Connector):
         if data == None:
             client.delete(_hash)
         else:
-            client.hmset(_hash, self.__typed_to_raw(data))
+            # We allow deletion of field by setting them to None, __typed_to_raw()
+            # will fill keys to be deleted in dkeys arg.
+            dkeys = dict()
+            raw = self.__typed_to_raw(data, dkeys)
+            if raw and len(raw):
+                client.hmset(_hash, raw)
+            # check if any dkeys(i.e. fields) to be deleted
+            if len(dkeys):
+                # get the original first, nothing to do if original is None
+                original = self.get_entry(table, key)
+                if original:
+                    self.__delete_fields(client, _hash, dkeys, original)
+
+            return
+
+    def __delete_fields(self, client, _hash, fields, original):
+        """Delete fields under a key(_hash) of a table in config db.
+        Args:
+            client: db client
+            _hash: _hash of the key, where fields to be deleted
+            fields: fields to be deleted, a dict as {field1: None, field2: None, ...}
+            original: original value of _hash i.e. field, value dict.
+        """
+        for k in fields:
+            v = original.get(k)
+            # nothing to do if v is None
+            if v:
+                if type(v) == list:
+                    k = k + '@'
+                client.hdel(_hash, self.serialize_key(k))
+        return
 
     def get_entry(self, table, key):
         """Read a table entry from config db.
         Args:
             table: Table name.
             key: Key of table entry, or a tuple of keys if it is a multi-key table.
-        Returns: 
+        Returns:
             Table row data in a form of dictionary {'column_key': 'value', ...}
             Empty dictionary if table does not exist or entry does not exist.
         """
@@ -220,7 +252,7 @@ class ConfigDBConnector(SonicV2Connector):
             table: Table name.
             split: split the first part and return second.
                    Useful for keys with two parts <tablename>:<key>
-        Returns: 
+        Returns:
             List of keys.
         """
         client = self.get_redis_client(self.db_name)
@@ -244,8 +276,8 @@ class ConfigDBConnector(SonicV2Connector):
         """Read an entire table from config db.
         Args:
             table: Table name.
-        Returns: 
-            Table data in a dictionary form of 
+        Returns:
+            Table data in a dictionary form of
             { 'row_key': {'column_key': value, ...}, ...}
             or { ('l1_key', 'l2_key', ...): {'column_key': value, ...}, ...} for a multi-key table.
             Empty dictionary if table does not exist.
@@ -286,7 +318,7 @@ class ConfigDBConnector(SonicV2Connector):
            Extra entries/fields in the db which are not in the data are kept.
         Args:
             data: config data in a dictionary form
-            { 
+            {
                 'TABLE_NAME': { 'row_key': {'column_key': 'value', ...}, ...},
                 'MULTI_KEY_TABLE_NAME': { ('l1_key', 'l2_key', ...) : {'column_key': 'value', ...}, ...},
                 ...
@@ -301,10 +333,10 @@ class ConfigDBConnector(SonicV2Connector):
                 self.mod_entry(table_name, key, table_data[key])
 
     def get_config(self):
-        """Read all config data. 
+        """Read all config data.
         Returns:
-            Config data in a dictionary form of 
-            { 
+            Config data in a dictionary form of
+            {
                 'TABLE_NAME': { 'row_key': {'column_key': 'value', ...}, ...},
                 'MULTI_KEY_TABLE_NAME': { ('l1_key', 'l2_key', ...) : {'column_key': 'value', ...}, ...},
                 ...
@@ -324,4 +356,3 @@ class ConfigDBConnector(SonicV2Connector):
             except ValueError:
                 pass    #Ignore non table-formated redis entries
         return data
-


### PR DESCRIPTION
With config Validation in place, we should reply on validating config
and should allow other operations such as deletion of field, if needed by user.

Signed-off-by: Praveen Chaudhary pchaudhary@linkedin.com


#### This may be needed since an ACL_TABLE or LAG may exist without the port, specially during port breakout.

Testing:
Delete field Using a file:


```
127.0.0.1:6379[4]> hgetall "ACL_TABLE|NO-NSW-PACL-TEST"
1) "type"
2) "L3"
3) "policy_desc"
4) "NO-NSW-PACL-TEST"
5) "ports@"
6) "Ethernet0,Ethernet2”

admin@lnos-x1-a-fab01:~/test_pc_load_yang$ cat new_acl.json 
{
    "ACL_TABLE": {
        "NO-NSW-PACL-TEST": {
                "ports": null
        }
    }
}

admin@lnos-x1-a-fab01:~/test_pc_load_yang$ sudo config load new_acl.json -d -y
Running command: /usr/local/bin/sonic-cfggen -j new_acl.json --write-to-db


127.0.0.1:6379[4]> hgetall "ACL_TABLE|NO-NSW-PACL-TEST"
1) "type"
2) "L3"
3) "policy_desc"
4) "NO-NSW-PACL-TEST"
127.0.0.1:6379[4]> 

admin@lnos-x1-a-fab01:~/test_pc_load_yang$ show acl table NO-NSW-PACL-TEST
Name              Type    Binding    Description       Stage
----------------  ------  ---------  ----------------  -------
NO-NSW-PACL-TEST  L3                 NO-NSW-PACL-TEST  ingress
```


Using Dynamic Port Breakout, Here we are deleting all ports inside the ACL_TABLE due to breakout
```
admin@lnos-x1-a-fab01:~/test_pc_load_yang$ sonic-cfggen -d --print-data | grep -A 20 ACL_TABLE
    "ACL_TABLE": {
        "NO-NSW-PACL-TEST": {
            "policy_desc": "NO-NSW-PACL-TEST", 
            "ports": [
                "Ethernet0", 
                "Ethernet2"
            ], 
            "type": "L3"
        }, 
        "NO-NSW-PACL-V4": {
            "policy_desc": "NO-NSW-PACL-V4", 
            "ports": [
                "Ethernet76", 
                "Ethernet77", 
                "Ethernet74", 

admin@lnos-x1-a-fab01:~/test_pc_load_yang$ sudo config interface breakout Ethernet0 2x50G -y -f -l

Running Breakout Mode : 4x25G[10G]
Target Breakout Mode : 2x50G

….



admin@lnos-x1-a-fab01:~/test_pc_load_yang$ sonic-cfggen -d --print-data | grep -A 20 ACL_TABLE
    "ACL_TABLE": {
        "NO-NSW-PACL-TEST": {
            "policy_desc": "NO-NSW-PACL-TEST", 
            "type": "L3"
        }, 
        "NO-NSW-PACL-V4": {
            "policy_desc": "NO-NSW-PACL-V4", 
            "ports": [
                "Ethernet76", 
                "Ethernet77", 
                "Ethernet74", 
                "Ethernet75", 
                "Ethernet72", 
                "Ethernet73", 
                "Ethernet70", 

admin@lnos-x1-a-fab01:~/test_pc_load_yang$ show acl table NO-NSW-PACL-TEST
Name              Type    Binding    Description       Stage
----------------  ------  ---------  ----------------  -------
NO-NSW-PACL-TEST  L3                 NO-NSW-PACL-TEST  ingress
```

DPB VS test run:
```
       self.dvs_acl.verify_acl_table_count(1)

        #TBD: Uncomment this, or explain why Ethernet0 is being added back to ACL table
        # Also, string "None" is being added as port to ACL port list after the breakout
        self.dvs_acl.verify_acl_group_num(0)

        # Verify child ports are created.
        self.verify_only_ports_exist(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])

        # Enable below snippet after fixing the above issues
        '''
        # Move back to 1x100G[40G] mode and verify current mode
        dvs.change_port_breakout_mode("Ethernet0", "1x100G[40G]", "-f")
        dpb.verify_port_breakout_mode(dvs, "Ethernet0", "1x100G[40G]")
        '''

"test_port_dpb_system.py" 227L, 11170C written
svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --dvsname=vs-jk test_port_dpb_system.py -k test_port_breakout_with_acl --junitxml=report.xml
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.3.0, py-1.6.0, pluggy-0.6.0
rootdir: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 2 items

test_port_dpb_system.py .                                                [100%]

 generated xml file: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests/report.xml
============================== 1 tests deselected ==============================
=================== 1 passed, 1 deselected in 91.24 seconds ====================
```

Latest Run: [06/03/2020]
```
svc-lnos-user@server10:/home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --dvsname=vs-jk test_port_dpb_system.py -k test_port_breakout_with_acl --junitxml=report.xml | tee out
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.3.0, py-1.6.0, pluggy-0.6.0
rootdir: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 2 items

test_port_dpb_system.py .                                                [100%]

 generated xml file: /home/svc-lnos-user/praveen/sonic-buildimage/src/sonic-swss/tests/report.xml
============================== 1 tests deselected ==============================
=================== 1 passed, 1 deselected in 79.96 seconds ====================
```